### PR TITLE
Adding support for de-interleaving stacks

### DIFF
--- a/TIFFStack.m
+++ b/TIFFStack.m
@@ -448,7 +448,7 @@ classdef TIFFStack < handle
                   % - Check trailing dimensions for inappropriate indices
                   if (any(vbTrailing & (~vbIsColon & ~vbIsUnitary & ~vbIsEmpty)))
                      % - This is an error
-                     error('TIFFStack:badsubscript', ...
+                     error('TIFFStack:BadSubscript', ...
                         '*** TIFFStack: Index exceeds stack dimensions.');
                   end
                   
@@ -536,7 +536,7 @@ classdef TIFFStack < handle
          % - Return specific dimension(s)
          if (exist('vnDimensions', 'var'))
             if (~isnumeric(vnDimensions) || any(vnDimensions < 1))
-               error('TIFFStack:dimensionMustBePositiveInteger', ...
+               error('TIFFStack:DimensionMustBePositiveInteger', ...
                   '*** TIFFStack: Dimensions argument must be a positive integer.');
             end
             
@@ -610,7 +610,7 @@ classdef TIFFStack < handle
       function set.bInvert(oStack, bInvert)
          % - Check contents
          if (~islogical(bInvert) || ~isscalar(bInvert))
-            error('TIFFStack:invalidArgument', ...
+            error('TIFFStack:InvalidArgument', ...
                   '*** TIFFStack/set.bInvert: ''bInvert'' must be a logical scalar.');
          else
             % - Assign bInvert value
@@ -649,7 +649,7 @@ function [tfData] = TS_read_data_tiffread(oStack, cIndices, bLinearIndexing)
    vnMaxRange = cellfun(@(c)(max(c)), cIndices);
    
    if (any(vnMinRange < 1) || any(vnMaxRange > oStack.vnDataSize))
-      error('TIFFStack:badsubscript', ...
+      error('TIFFStack:BadSubscript', ...
             '*** TIFFStack: Index exceeds stack dimensions.');
    end
    
@@ -725,7 +725,7 @@ function [tfData] = TS_read_data_Tiff(oStack, cIndices, bLinearIndexing)
    vnMaxRange = cellfun(@(c)(max(c(:))), cIndices(~vbIsColon));
    
    if (any(vnMinRange < 1) || any(vnMaxRange > oStack.vnDataSize(~vbIsColon)))
-      error('TIFFStack:badsubscript', ...
+      error('TIFFStack:BadSubscript', ...
          '*** TIFFStack: Index exceeds stack dimensions.');
    end
    
@@ -904,7 +904,7 @@ function isvalidsubscript(oRefs)
       end
       
    catch
-      error('TIFFStack:badsubscript', ...
+      error('TIFFStack:BadSubscript', ...
             '*** TIFFStack: Subscript indices must either be real positive integers or logicals.');
    end
 end

--- a/TIFFStack.m
+++ b/TIFFStack.m
@@ -478,10 +478,14 @@ classdef TIFFStack < handle
                
                % reinterpret indices for deinterleaved files
                if numel(oStack.vnApparentSize) > 4
-                  idx = reshape(1:oStack.vnDataSize(3), ...
-                                oStack.vnApparentSize(3:end-1));
                   cSubs = S.subs(3:end-1);
-                  S.subs = {S.subs{1} S.subs{2}  idx(cSubs{:}) S.subs{end}};
+                  if all(cellfun(@iscolon, cSubs))
+                     S.subs = {S.subs{1} S.subs{2}  ':' S.subs{end}};
+                  else
+                     mIdx = reshape(1:oStack.vnDataSize(3), ...
+                                    oStack.vnApparentSize(3:end-1));
+                     S.subs = {S.subs{1} S.subs{2}  mIdx(cSubs{:}) S.subs{end}};
+                  end
                end
 
                % - Access stack (tifflib or tiffread)


### PR DESCRIPTION
Some `TIFF` stacks are created without using multiple samples per pixel, but by interleaving channels (and /or slices) into several adjacent frames. This implies that the `frames` axis of the stack is actually `frames x slices x channels` or something similar.

This pull request adds support for de-interleaving these stacks transparently within `TIFFStack`.
