### PR TITLE
loadobj for TIFFStack

### DIFF
--- a/TIFFStack.m
+++ b/TIFFStack.m
@@ -144,6 +144,7 @@ classdef TIFFStack < handle
    end
    
    properties (SetAccess = private, GetAccess = private)
+      bForceTiffread       % - forcing tiffread, rather than libTiff
       vnDataSize;          % - Cached size of the TIFF stack
       vnApparentSize;      % - Apparent size of the TIFF stack
       TIF;                 % \_ Cached header info for tiffread29 speedups
@@ -151,7 +152,7 @@ classdef TIFFStack < handle
       bUseTiffLib;         % - Flag indicating whether TiffLib is being used
       fhReadFun;           % - When using Tiff class, function for reading data
       fhSetDirFun;         % - When using Tiff class, function for setting the directory
-      vnDimensionOrder;    % - Internal dimensions order to support permution
+      vnDimensionOrder;    % - Internal dimensions order to support permutation
       fhRepSum;            % - Function handle to (hopefully) accellerated repsum function
       fhCastFun;           % - The matlab function that casts data to the required return class
    end
@@ -170,6 +171,7 @@ classdef TIFFStack < handle
          if (~exist('bForceTiffread', 'var') || isempty(bForceTiffread))
             bForceTiffread = false;
          end
+         oStack.bForceTiffread = bForceTiffread;
          
          % - Can we use the accelerated TIFF library?
          if (exist('tifflib') ~= 3) %#ok<EXIST>
@@ -727,7 +729,21 @@ classdef TIFFStack < handle
             oStack.bInvert = bInvert;
          end
       end
-      
+
+   end
+
+   methods (Static)
+      % Overloaded loadobj
+      function oStack = loadobj(sSavedVar)
+         % Create a new TIFFStack
+         oStack = TIFFStack(sSavedVar.strFilename, sSavedVar.bInvert, [], ...
+                            sSavedVar.bForceTiffread);
+
+         % Adjust dimensions to look like saved stack
+         oStack.vnApparentSize = sSavedVar.vnApparentSize;
+         oStack.vnDimensionOrder = sSavedVar.vnDimensionOrder;
+      end
+
    end
 end
 


### PR DESCRIPTION
This commit add a loadobj method useable with default saveobj.
Tested with parfor loops, it works :-).
