### PR TITLE
Bugfix in size for stack with unitary dimension

### DIFF
--- a/TIFFStack.m
+++ b/TIFFStack.m
@@ -723,7 +723,7 @@ classdef TIFFStack < handle
          % - Trim trailing unitary dimensions
          vbIsUnitary = vnSize == 1;
          if (vbIsUnitary(end))
-            nLastNonUnitary = find(1-vbIsUnitary, 1, 'last');
+            nLastNonUnitary = find(~vbIsUnitary, 1, 'last');
             if (nLastNonUnitary < numel(vnSize))
                vnSize = vnSize(1:nLastNonUnitary);
             end

--- a/TIFFStack.m
+++ b/TIFFStack.m
@@ -723,7 +723,7 @@ classdef TIFFStack < handle
          % - Trim trailing unitary dimensions
          vbIsUnitary = vnSize == 1;
          if (vbIsUnitary(end))
-            nLastNonUnitary = numel(vnSize) - find(fliplr(vnSize) == 1, 1, 'last');
+            nLastNonUnitary = find(1-vbIsUnitary, 1, 'last');
             if (nLastNonUnitary < numel(vnSize))
                vnSize = vnSize(1:nLastNonUnitary);
             end


### PR DESCRIPTION
Was stopping at the first unitary dimension instead of removing the trailing
unitary dimension.

Should fix [issue 10](https://github.com/DylanMuir/TIFFStack/issues/10)
