### PR TITLE
desactivate permutation of dimensions (for IJ) if manual deinterleaving

### DIFF
--- a/TIFFStack.m
+++ b/TIFFStack.m
@@ -256,10 +256,11 @@ classdef TIFFStack < handle
             end
             
             % - Deinterleave hyperstacks automatically
-            if (bIsImageJHyperStack && isempty(vnInterleavedFrameDims))
+            bImageJDeinterleaving = bIsImageJHyperStack && isempty(vnInterleavedFrameDims);
+            if bImageJDeinterleaving
                vnInterleavedFrameDims = vnInterleavedIJFrameDims;
             end
-            
+
             % - Initialise object, depending on underlying access method
             if (oStack.bMTStack)
                % - Fix up stack size
@@ -445,7 +446,7 @@ classdef TIFFStack < handle
             oStack.vnDimensionOrder = 1:numel(oStack.vnApparentSize);
             
             % - Fix up dimensions order for ImageJ HyperStack
-            if (bIsImageJHyperStack)
+            if (bImageJDeinterleaving)
                oStack = permute(oStack, [1 2 5 4 3]);
             end
 


### PR DESCRIPTION
Manual de-interleaving of an ImageJ hyperstack does not interact well with ImageJ automatic dimension permutation. Here I propose to switch off dimension permutation if user provide deinterleaving dimensions.