### PR TITLE
add Software tag in TIFF header parser

### DIFF
--- a/private/tiffread31_info.m
+++ b/private/tiffread31_info.m
@@ -196,6 +196,8 @@ while ifd_pos ~= 0
             TIF.PlanarConfiguration = entry_val;
          case 339
             TIF.SampleFormat = entry_val;
+         case 305
+            INFO(img_indx).Software = entry_val;
       end
    end
    


### PR DESCRIPTION
Add 'Software' tag, used by ScanImage.