### PR TITLE
fix bug: wrong apparent size with lazy deinterleaving

### DIFF
--- a/TIFFStack.m
+++ b/TIFFStack.m
@@ -447,6 +447,7 @@ classdef TIFFStack < handle
                   % - Work out number of apparent frames
                   nNumApparentFrames = oStack.vnDataSize(3) ./ prod(vnInterleavedFrameDims);
                   oStack.vnApparentSize = [oStack.vnDataSize(1:2) vnInterleavedFrameDims(:)' nNumApparentFrames oStack.vnDataSize(4)];
+                  oStack.vnDimensionOrder = 1:numel(oStack.vnApparentSize);
                   
                else
                   % - Incorrect total number of deinterleaved frames

--- a/private/TS_UnitTest.m
+++ b/private/TS_UnitTest.m
@@ -145,7 +145,15 @@ function TSUT_RunTestsOnFile(strFilename)
    assert(isequal(size(tsStack), vnTestSize), ...
           'TIFFStack:UnitTestFailed', 'De-interleaving the stack was unsuccessful.');
 
-	TSUT_assertFail('MATLAB:TIFFStack:expectedInteger', 'TIFFStack(strFilename, [], .5);');
+   tsStack = TIFFStack(strFilename, [], [1 1]);
+   vnTestSize = [vnStackSize([1 2]) 1 1 nNumFrames vnStackSize(4:end)];
+   if (vnTestSize(end) == 1)
+      vnTestSize = vnTestSize(1:(find(vnTestSize == 1, 1, 'last') - 1));
+   end
+   assert(isequal(size(tsStack), vnTestSize), ...
+          'TIFFStack:UnitTestFailed', 'De-interleaving the stack was unsuccessful.');
+
+   TSUT_assertFail('MATLAB:TIFFStack:expectedInteger', 'TIFFStack(strFilename, [], .5);');
        
    tfStack = reshape(tfStack, [size(tfStack, 1) size(tfStack, 2) 1 1 nNumFrames size(tfStack, 4)]);
    TSUT_TestReferencing(tsStack, tfStack, 'Deinterleaved stack');


### PR DESCRIPTION
There was a bug with size of a lazily deinterleaved stack:
``` matlab
stack = TIFFStack('my_stack.tif', [], [4, 1]);  % using a [512, 512, 900] stack
size(stack);  % gives [512, 512, 4, 1] instead of [512, 512, 4, 1, 225]
```