### PR TITLE
Modify offset to uint64 in tiffread31_readtags

### DIFF
--- a/private/tiffread31_readtags.m
+++ b/private/tiffread31_readtags.m
@@ -353,7 +353,7 @@ end
       
       if nbBytes * entry_cnt > nInlineBytes
          % next field contains an offset
-         fpos = fread(TIF.file, 1, 'uint32', TIF.ByteOrder);
+         fpos = fread(TIF.file, 1, 'uint64', TIF.ByteOrder);
          file_seek(fpos);
       end
       


### PR DESCRIPTION
Tags found in frames over 4gb could not be read since the offset was read as an uint32. I'm not sure if it could break non-big tiff or where to find how is the offset encoded. This PR works for ScanImage files (n=1)